### PR TITLE
fix: Repair generator and add site navigation

### DIFF
--- a/generator.md
+++ b/generator.md
@@ -18,6 +18,28 @@ Kliknij przycisk poniżej, aby wylosować unikalny scenariusz do Twojej następn
   var emocje = {{ site.data.emocje | to_json }};
   var zawody = {{ site.data.zawody | to_json }};
   var miejsca = {{ site.data.miejsca | to_json }};
-</script>
 
-<script src="{{ site.baseurl }}/assets/js/generator.js"></script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const button = document.getElementById('generator-button');
+    const resultDiv = document.getElementById('generator-sceny-wynik');
+
+    if (button) {
+      button.addEventListener('click', function() {
+        if (typeof emocje !== 'undefined' && typeof zawody !== 'undefined' && typeof miejsca !== 'undefined' && emocje.length > 0 && zawody.length > 0 && miejsca.length > 0) {
+          const losowaEmocja = emocje[Math.floor(Math.random() * emocje.length)];
+          const losowyZawod = zawody[Math.floor(Math.random() * zawody.length)];
+          const losoweMiejsce = miejsca[Math.floor(Math.random() * miejsca.length)];
+
+          resultDiv.innerHTML = `
+            <h3>Twoja Scena:</h3>
+            <p><strong>Jesteś jako:</strong> ${losowyZawod.nazwa}</p>
+            <p><strong>Odczuwasz:</strong> ${losowaEmocja.nazwa}</p>
+            <p><strong>Znajdujesz się w:</strong> ${losoweMiejsce.nazwa}</p>
+          `;
+        } else {
+          resultDiv.innerHTML = "<p>Błąd: Nie można załadować danych. Sprawdź, czy pliki w folderze _data istnieją i mają poprawną treść.</p>";
+        }
+      });
+    }
+  });
+</script>


### PR DESCRIPTION
Resolves the "Generate Scene" button functionality by embedding the generator script directly into `generator.md`. This ensures the script has access to the Liquid-populated data variables, fixing the data loading error.

Adds a site-wide navigation menu by creating a custom `_layouts/default.html` to override the theme's default. The new layout renders navigation links based on the configuration in `_config.yml`.